### PR TITLE
Fix issue #1 : Cannot run headless

### DIFF
--- a/plot_style.py
+++ b/plot_style.py
@@ -7,7 +7,8 @@ Plot styles available to draw from PNGProfileFormat
 """
 
 import math
-
+import matplotlib
+matplotlib.use('Agg')
 import numpy as np
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
matplotlib should be set to Agg mode before invoking numpy

Reference : http://matplotlib.org/faq/howto_faq.html#generate-images-without-having-a-window-appear

Signed-off-by: CapsLock faimaison@legeox.net
